### PR TITLE
Add non-recursive printing of SMT-LIB expressions

### DIFF
--- a/validate-model.py
+++ b/validate-model.py
@@ -65,7 +65,7 @@ for cmd in cmds:
             defs.append(cmd)
 
 for cmd in defs:
-    for line in smtlib.print_expr(cmd):
+    for line in smtlib.print_expr_non_recursive(cmd):
         print(line)
 
 goal = ("assert", ("not", ("and", *clauses)))


### PR DESCRIPTION
Recursion limit in Python is set to 1000 by default, and cannot really be increased much without running into system's limits on stack size.
Therefore I propose to add a non-recursive version of expression printer. This should help with model validation for models with deep terms.